### PR TITLE
Modified resigning procedure to automatically copy the target provisioni...

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.h
+++ b/iReSign/iReSign/iReSignAppDelegate.h
@@ -19,6 +19,7 @@
     NSTask *unzipTask;
     NSTask *provisioningTask;
     NSTask *codesignTask;
+    NSTask *generateEntitlementsTask;
     NSTask *verifyTask;
     NSTask *zipTask;
     NSString *originalIpaPath;
@@ -27,6 +28,7 @@
     NSString *appName;
     NSString *fileName;
     
+    NSString *entitlementsResult;
     NSString *codesigningResult;
     NSString *verificationResult;
     


### PR DESCRIPTION
This prevents a crash when accessing the iOS keychain after resigning the ipa. This happens because the keychain access group differs between profiles and MUST be updated to make use of the keychain.
