### PR TITLE
Update iReSignAppDelegate.m

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -304,14 +304,32 @@ static NSString *kiTunesMetadataFileName        = @"iTunesMetadata";
     
     if (appPath) {
         NSMutableArray *arguments = [NSMutableArray arrayWithObjects:@"-fs", [certComboBox objectValue], nil];
-	
+		
 	NSDictionary *systemVersionDictionary = [NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"];
 	float systemVersionFloat = [[systemVersionDictionary objectForKey:@"ProductVersion"] floatValue];
 	if (systemVersionFloat < 10.9f) {
-		// add the resources flag for version 1 code signatures, only valid before OSX 10.9
+		
+		/*
+		 Before OSX 10.9, code signing requires a version 1 signature.
+		 The resource envelope is necessary.
+		 To ensure it is added, append the resource flag to the arguments.
+		 */
+		
 		NSString *resourceRulesPath = [[NSBundle mainBundle] pathForResource:@"ResourceRules" ofType:@"plist"];
 		NSString *resourceRulesArgument = [NSString stringWithFormat:@"--resource-rules=%@",resourceRulesPath];
 		[arguments addObject:resourceRulesArgument];
+	} else {
+		
+		/*
+		 For OSX 10.9 and later, code signing requires a version 2 signature.
+		 The resource envelope is obsolete.
+		 To ensure it is ignored, remove the resource key from the Info.plist file.
+		 */
+		
+		NSString *infoPath = [NSString stringWithFormat:@"%@/Info.plist", appPath];
+		NSMutableDictionary *infoDict = [NSMutableDictionary dictionaryWithContentsOfFile:infoPath];
+		[infoDict removeObjectForKey:@"CFBundleResourceSpecification"];
+		[infoDict writeToFile:infoPath atomically:YES];
 	}
         
         if (![[entitlementField stringValue] isEqualToString:@""]) {


### PR DESCRIPTION
Added conditional to only add the resources flag for version 1 code signing (used before OSX 10.9).  The resources flag is obsolete for version 2 code signing, see this page for more information:

https://developer.apple.com/library/prerelease/mac/technotes/tn2206/_index.html
