### PR TITLE
Add --no-strict argument to codesign to avoid “Resource envelope is obso...

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -330,6 +330,7 @@ static NSString *kiTunesMetadataFileName        = @"iTunesMetadata";
 		NSMutableDictionary *infoDict = [NSMutableDictionary dictionaryWithContentsOfFile:infoPath];
 		[infoDict removeObjectForKey:@"CFBundleResourceSpecification"];
 		[infoDict writeToFile:infoPath atomically:YES];
+		[arguments addObject:@"--no-strict"]; // http://stackoverflow.com/a/26204757
 	}
         
         if (![[entitlementField stringValue] isEqualToString:@""]) {


### PR DESCRIPTION
...lete” errors.
