### PR TITLE
Update iReSignAppDelegate.m

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -306,8 +306,9 @@ static NSString *kiTunesMetadataFileName        = @"iTunesMetadata";
         NSMutableArray *arguments = [NSMutableArray arrayWithObjects:@"-fs", [certComboBox objectValue], nil];
 		
 	NSDictionary *systemVersionDictionary = [NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"];
-	float systemVersionFloat = [[systemVersionDictionary objectForKey:@"ProductVersion"] floatValue];
-	if (systemVersionFloat < 10.9f) {
+	NSString * systemVersion = [systemVersionDictionary objectForKey:@"ProductVersion"];
+    	NSArray * version = [systemVersion componentsSeparatedByString:@"."];
+	if ([version[0] intValue]<10 || ([version[0] intValue]==10 && [version[1] intValue]<=9)) {
 		
 		/*
 		 Before OSX 10.9, code signing requires a version 1 signature.


### PR DESCRIPTION
Using floatValue will not work with OSX 10.10, because 10.10 in floatValue is < than 10.9
