### PR TITLE
Fix version detection logic for 10.9.5

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -446,7 +446,7 @@ static NSString *kiTunesMetadataFileName            = @"iTunesMetadata";
         NSDictionary *systemVersionDictionary = [NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"];
         NSString * systemVersion = [systemVersionDictionary objectForKey:@"ProductVersion"];
         NSArray * version = [systemVersion componentsSeparatedByString:@"."];
-        if ([version[0] intValue]<10 || ([version[0] intValue]==10 && [version[1] intValue]<=9)) {
+        if ([version[0] intValue]<10 || ([version[0] intValue]==10 && ([version[1] intValue]<9 || ([version[1] intValue]==9 && [version[2] intValue]<5)))) {
             
             /*
              Before OSX 10.9, code signing requires a version 1 signature.


### PR DESCRIPTION
This fixes a regression for https://github.com/maciekish/iReSign/issues/26 .  OS X 10.9.5 should get the same signing behavior as 10.10.