### PR TITLE
Fixed off-by-one error

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -306,7 +306,7 @@ static NSString *kiTunesMetadataFileName            = @"iTunesMetadata";
                     NSArray* embeddedProvisioningLines = [embeddedProvisioning componentsSeparatedByCharactersInSet:
                                                           [NSCharacterSet newlineCharacterSet]];
                     
-                    for (int i = 0; i <= [embeddedProvisioningLines count]; i++) {
+                    for (int i = 0; i < [embeddedProvisioningLines count]; i++) {
                         if ([[embeddedProvisioningLines objectAtIndex:i] rangeOfString:@"application-identifier"].location != NSNotFound) {
                             
                             NSInteger fromPosition = [[embeddedProvisioningLines objectAtIndex:i+1] rangeOfString:@"<string>"].location + 8;


### PR DESCRIPTION
There is an off-by-one error when we are looking for the line with "application-identifier". Bug is not evident for now because it is always found in the file.