### PR TITLE
Enable resigning of apps with Swift dylibs included

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -446,7 +446,8 @@ static NSString *kiTunesMetadataFileName            = @"iTunesMetadata";
                 hasFrameworks = YES;
                 NSArray *frameworksContents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:frameworksDirPath error:nil];
                 for (NSString *frameworkFile in frameworksContents) {
-                    if ([[[frameworkFile pathExtension] lowercaseString] isEqualTo:@"framework"]) {
+                    NSString *extension = [[frameworkFile pathExtension] lowercaseString];
+                    if ([extension isEqualTo:@"framework"] || [extension isEqualTo:@"dylib"]) {
                         frameworkPath = [frameworksDirPath stringByAppendingPathComponent:frameworkFile];
                         NSLog(@"Found %@",frameworkPath);
                         [frameworks addObject:frameworkPath];


### PR DESCRIPTION
PR#46 included support for signing frameworks included in the app.
Same thing needs to be done for dylibs (for Swift)