### PR TITLE
Fix Bundle ID verification bug

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -338,8 +338,8 @@ static NSString *kiTunesMetadataFileName            = @"iTunesMetadata";
                     
                     NSLog(@"Mobileprovision identifier: %@",identifierInProvisioning);
                     
-                    NSString *infoPlist = [NSString stringWithContentsOfFile:[appPath stringByAppendingPathComponent:@"Info.plist"] encoding:NSASCIIStringEncoding error:nil];
-                    if ([infoPlist rangeOfString:identifierInProvisioning].location != NSNotFound) {
+                    NSDictionary *infoplist = [NSDictionary dictionaryWithContentsOfFile:[appPath stringByAppendingPathComponent:@"Info.plist"]];
+                    if ([identifierInProvisioning isEqualTo:[infoplist objectForKey:kKeyBundleIDPlistApp]]) {
                         NSLog(@"Identifiers match");
                         identifierOK = TRUE;
                     }


### PR DESCRIPTION
The current implementation of the verification only checks if the string is in the sequence, so checking "com.company.test1234" will pass if the bundle id should be "com.company.test1".
Bundle ID should be exact strings.
