### PR TITLE
Resign all frameworks

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -461,8 +461,10 @@ static NSString *kiTunesMetadataFileName            = @"iTunesMetadata";
     
     if (appPath) {
         if (hasFrameworks) {
-            [self signFile:[frameworks lastObject]];
-            [frameworks removeLastObject];
+            for (NSString *framework in frameworks) {
+                [self signFile:framework];
+            }
+            [frameworks removeAllObjects];
         } else {
             [self signFile:appPath];
         }
@@ -540,8 +542,10 @@ static NSString *kiTunesMetadataFileName            = @"iTunesMetadata";
         [timer invalidate];
         codesignTask = nil;
         if (frameworks.count > 0) {
-            [self signFile:[frameworks lastObject]];
-            [frameworks removeLastObject];
+            for (NSString *framework in frameworks) {
+                [self signFile:framework];
+            }
+            [frameworks removeAllObjects];
         } else if (hasFrameworks) {
             hasFrameworks = NO;
             [self signFile:appPath];


### PR DESCRIPTION
Fix problem like 

> [deny-mmap] mapped file does not the same team identifier as main process: /private/var/mobile/Containers/Bundle/Application/57503E66-DC05-4F83-8EBC-1DC914238ACA/Demo.app/Frameworks/A-Framework.framework 

because only the last framework under framework folder is resigned.
