### PR TITLE
修改在10.12中生成entitlements.plist文件失败的情况.

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -411,6 +411,11 @@ static NSString *kiTunesMetadataFileName            = @"iTunesMetadata";
 
 - (void)doEntitlementsEdit
 {
+    if ([entitlementsResult containsString:@"SecPolicySetValue"]) {
+        NSMutableArray *linesInOutput=[NSMutableArray arrayWithArray:[entitlementsResult componentsSeparatedByString:@"\n"]];
+        [linesInOutput removeObjectAtIndex:0];
+        entitlementsResult=[linesInOutput componentsJoinedByString:@"\n"];
+    }
     NSDictionary* entitlements = entitlementsResult.propertyList;
     entitlements = entitlements[@"Entitlements"];
     NSString* filePath = [workingPath stringByAppendingPathComponent:@"entitlements.plist"];


### PR DESCRIPTION
在macOS 10.12中运行失败,原因是因为生成entitlements.plist有问题,修改上传;