### PR TITLE
Fix the xml start location of security command line output bug

### DIFF
--- a/iReSign/iReSign/iReSignAppDelegate.m
+++ b/iReSign/iReSign/iReSignAppDelegate.m
@@ -411,6 +411,11 @@ static NSString *kiTunesMetadataFileName            = @"iTunesMetadata";
 
 - (void)doEntitlementsEdit
 {
+    NSString *xmlStartStr = @"<?xml";
+    NSRange range = [entitlementsResult rangeOfString:xmlStartStr];
+    if (range.location != NSNotFound) {
+        entitlementsResult = [entitlementsResult substringFromIndex: range.location];
+    }
     NSDictionary* entitlements = entitlementsResult.propertyList;
     entitlements = entitlements[@"Entitlements"];
     NSString* filePath = [workingPath stringByAppendingPathComponent:@"entitlements.plist"];


### PR DESCRIPTION
When I use ```security cms -D -i embedded.mobileprovision ``` in terminal on my Mac (macOS 10.12.1) it will output an warning string as below 
```security: SecPolicySetValue: One or more parameters passed to a function were not valid.```.

Therefore, when I resigned my ipa file it will block at the process of "Entitlements generated".
So, I fix it by finding the xml start location in order to get the correct plist data.

